### PR TITLE
Add memos.json

### DIFF
--- a/notes/memos.json
+++ b/notes/memos.json
@@ -1,5 +1,5 @@
 {
-  entries: [
-    { name: "#til `HTMLFormElement.elements`", path: "html-form-elements.md" }
+  "entries": [
+    { "name": "#til `HTMLFormElement.elements`", "path": "html-form-elements.md" }
   ]
 }

--- a/notes/memos.json
+++ b/notes/memos.json
@@ -1,0 +1,5 @@
+{
+  entries: [
+    { name: "#til `HTMLFormElement.elements`", path: "html-form-elements.md" }
+  ]
+}


### PR DESCRIPTION
Hi @kcjpop , thanks for using memos.pub! Since you are one of the first to try it out, I'd love to support you to the fullest!

Anyway, I notice that you are using a slug-friendly format for your file names. This is great because it produces clean URL (e.g. https://notes.ancaois.me/notes/html-form-elements.md). However, you may also notice that it doesn't look really good at the listing page (i.e. https://notes.ancaois.me/notes), as in the name is not super friendly.

<img width="1280" alt="image" src="https://user-images.githubusercontent.com/5953369/163681019-48043272-70a9-4091-b4f7-3332d9606cb2.png">


Good news that memos.pub support to have a different title in the listing page than using the file name. I created this PR to update it for you. To review it, I setup a demo for you to see at https://thien-do.memos.pub/kcjpop/notes

Note that in the "notes" page, it shows: "#til `HTMLFormElement.elements`", while the URL stays the same as https://thien-do.memos.pub/kcjpop/notes/html-form-elements.md. This is best of both worlds isn't it!

<img width="1280" alt="Screen Shot 2022-04-16 at 22 29 38" src="https://user-images.githubusercontent.com/5953369/163680927-bc5be7c7-7453-4dad-8ff2-90dcdff7f3af.png">

Next time you have a new article, just add another entry to the file. This is also useful when you are drafting one, as it won't be shown until you put it in memos.json. For a detailed interface of the config, please see https://github.com/thien-do/memos.pub/blob/main/lib/blog/list/config.ts
